### PR TITLE
Fix dependency management after merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,20 @@
 		<module>spring-boot-starter-web-reactive</module>
 		<module>spring-boot-sample-web-reactive</module>
 	</modules>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot.experimental</groupId>
+				<artifactId>spring-boot-autoconfigure-web-reactive</artifactId>
+				<version>0.1.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot.experimental</groupId>
+				<artifactId>spring-boot-starter-web-reactive</artifactId>
+				<version>0.1.0.BUILD-SNAPSHOT</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<profiles>
 		<profile>
 			<id>repositories</id>

--- a/spring-boot-autoconfigure-web-reactive/pom.xml
+++ b/spring-boot-autoconfigure-web-reactive/pom.xml
@@ -18,13 +18,18 @@
 		<url>http://www.spring.io</url>
 	</organization>
 	<properties>
-		<spring.reactive.version>0.1.0.BUILD-SNAPSHOT</spring.reactive.version>
-		<reactor.version>2.5.0.BUILD-SNAPSHOT</reactor.version>
+		<spring.version>5.0.0.BUILD-SNAPSHOT</spring.version>
+		<reactor.version>3.0.0.BUILD-SNAPSHOT</reactor.version>
+		<reactor-netty.version>0.5.0.BUILD-SNAPSHOT</reactor-netty.version>
 		<rx-netty.version>0.5.2-SNAPSHOT</rx-netty.version>
 		<jetty.version>9.3.10.v20160621</jetty.version>
 		<tomcat.version>8.5.3</tomcat.version>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web-reactive</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
@@ -32,23 +37,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-		</dependency>
-
-		<!-- TODO: remove when spring-reactive is merged into Spring Framework -->
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.reactive</groupId>
-			<artifactId>spring-reactive</artifactId>
-			<version>${spring.reactive.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -59,7 +47,7 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>${reactor.version}</version>
+			<version>${reactor-netty.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -83,12 +71,6 @@
 			<artifactId>rxnetty-http</artifactId>
 			<version>${rx-netty.version}</version>
 			<optional>true</optional>
-		</dependency>
-
-		<!-- TODO: remove those once merged into Spring Boot-->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-boot-sample-web-reactive/pom.xml
+++ b/spring-boot-sample-web-reactive/pom.xml
@@ -16,14 +16,14 @@
 
 	<properties>
 		<spring.version>5.0.0.BUILD-SNAPSHOT</spring.version>
-		<reactor.version>2.5.0.BUILD-SNAPSHOT</reactor.version>
+		<reactor.version>3.0.0.BUILD-SNAPSHOT</reactor.version>
+		<reactor-netty.version>0.5.0.BUILD-SNAPSHOT</reactor-netty.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot.experimental</groupId>
 			<artifactId>spring-boot-starter-web-reactive</artifactId>
-			<version>0.1.0.BUILD-SNAPSHOT</version>
 		</dependency>
 
 		<!-- uncomment next section to use reactor-netty -->
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>${reactor.version}</version>
+			<version>${reactor-netty.version}</version>
 		</dependency>
 		-->
 
@@ -75,7 +75,13 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>2.5.0.BUILD-SNAPSHOT</version>
+			<version>${reactor-netty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>4.1.0.Final</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-boot-sample-web-reactive/src/test/java/sample/web/reactive/ReactiveSampleApplicationTests.java
+++ b/spring-boot-sample-web-reactive/src/test/java/sample/web/reactive/ReactiveSampleApplicationTests.java
@@ -3,7 +3,7 @@ package sample.web.reactive;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.web.client.reactive.ClientWebRequestBuilders.get;
 import static org.springframework.web.client.reactive.ResponseExtractors.response;
-import static reactor.core.test.TestSubscriber.*;
+import static reactor.test.TestSubscriber.*;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/spring-boot-starter-web-reactive/pom.xml
+++ b/spring-boot-starter-web-reactive/pom.xml
@@ -25,7 +25,6 @@
 		<dependency>
 			<groupId>org.springframework.boot.experimental</groupId>
 			<artifactId>spring-boot-autoconfigure-web-reactive</artifactId>
-			<version>0.1.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -34,6 +33,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<!-- TODO this shouldn't be there -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-buffer</artifactId>
+			<version>4.1.0.Final</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
This commit migrates the project to Spring Framework 5.0 snapshots as
the reactive support has now been merged. There are still a few
outstanding issues related to netty and reactory that might justify a
separate BOM.
