### PR TITLE
Add bom infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
-	</parent>
 	<groupId>org.springframework.boot.experimental</groupId>
 	<artifactId>spring-boot-web-reactive</artifactId>
-	<packaging>pom</packaging>
 	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
 	<name>Spring Boot Web Reactive</name>
 	<description>Spring Boot Web Reactive</description>
 	<url>http://projects.spring.io/spring-boot/</url>
@@ -18,57 +13,18 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>http://www.spring.io</url>
 	</organization>
+
 	<properties>
 		<java.version>1.8</java.version>
 		<disable.checks>true</disable.checks>
 	</properties>
+
 	<modules>
 		<module>spring-boot-autoconfigure-web-reactive</module>
+		<module>spring-boot-dependencies-web-reactive</module>
+		<module>spring-boot-web-reactive-parent</module>
 		<module>spring-boot-starter-web-reactive</module>
 		<module>spring-boot-sample-web-reactive</module>
 	</modules>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot.experimental</groupId>
-				<artifactId>spring-boot-autoconfigure-web-reactive</artifactId>
-				<version>0.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.boot.experimental</groupId>
-				<artifactId>spring-boot-starter-web-reactive</artifactId>
-				<version>0.1.0.BUILD-SNAPSHOT</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-	<profiles>
-		<profile>
-			<id>repositories</id>
-			<activation>
-				<property>
-					<name>!skip-repositories</name>
-				</property>
-			</activation>
-			<repositories>
-				<repository>
-					<id>spring-snapshots</id>
-					<url>http://repo.spring.io/snapshot</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>oss-jfrog-snapshots</id>
-					<url>https://oss.jfrog.org/libs-snapshot</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-milestone</id>
-					<url>http://repo.spring.io/milestone</url>
-				</repository>
-			</repositories>
-		</profile>
-	</profiles>
+
 </project>

--- a/spring-boot-autoconfigure-web-reactive/pom.xml
+++ b/spring-boot-autoconfigure-web-reactive/pom.xml
@@ -4,11 +4,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.experimental</groupId>
-		<artifactId>spring-boot-web-reactive</artifactId>
+		<artifactId>spring-boot-web-reactive-parent</artifactId>
 		<version>0.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>../</relativePath> <!-- lookup parent from repository -->
+		<relativePath>../spring-boot-web-reactive-parent</relativePath>
 	</parent>
-
 	<artifactId>spring-boot-autoconfigure-web-reactive</artifactId>
 	<name>Spring Boot Web Reactive Auto-Configuration</name>
 	<description>Spring Boot Web Reactive Auto-Configuration</description>
@@ -17,20 +16,10 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>http://www.spring.io</url>
 	</organization>
-	<properties>
-		<spring.version>5.0.0.BUILD-SNAPSHOT</spring.version>
-		<reactor.version>3.0.0.BUILD-SNAPSHOT</reactor.version>
-		<reactor-ipc.version>0.5.0.BUILD-SNAPSHOT</reactor-ipc.version>
-		<rx-netty.version>0.5.2-SNAPSHOT</rx-netty.version>
-		<jetty.version>9.3.10.v20160621</jetty.version>
-		<tomcat.version>8.5.3</tomcat.version>
-		<undertow.version>1.4.0.CR3</undertow.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web-reactive</artifactId>
-			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -49,7 +38,6 @@
 		<dependency>
 			<groupId>io.projectreactor.ipc</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>${reactor-ipc.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -65,19 +53,16 @@
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxnetty-common</artifactId>
-			<version>${rx-netty.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxnetty-http</artifactId>
-			<version>${rx-netty.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-core</artifactId>
-			<version>${undertow.version}</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>

--- a/spring-boot-dependencies-web-reactive/pom.xml
+++ b/spring-boot-dependencies-web-reactive/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-dependencies</artifactId>
+		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<relativePath/>
+	</parent>
+	<groupId>org.springframework.boot.experimental</groupId>
+	<artifactId>spring-boot-dependencies-web-reactive</artifactId>
+	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>Spring Boot Web Reactive Dependencies</name>
+	<description>Spring Boot Web Reactive Dependency Management</description>
+	<url>http://projects.spring.io/spring-boot/</url>
+	<organization>
+		<name>Pivotal Software, Inc.</name>
+		<url>http://www.spring.io</url>
+	</organization>
+
+	<properties>
+		<netty.version>4.1.3.Final</netty.version>
+		<reactor.version>3.0.0.BUILD-SNAPSHOT</reactor.version>
+		<reactor-ipc.version>0.5.0.BUILD-SNAPSHOT</reactor-ipc.version>
+		<rx-netty.version>0.5.2-SNAPSHOT</rx-netty.version>
+		<spring.version>5.0.0.BUILD-SNAPSHOT</spring.version>
+		<undertow.version>1.4.0.CR3</undertow.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot.experimental</groupId>
+				<artifactId>spring-boot-autoconfigure-web-reactive</artifactId>
+				<version>0.1.0.BUILD-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot.experimental</groupId>
+				<artifactId>spring-boot-starter-web-reactive</artifactId>
+				<version>0.1.0.BUILD-SNAPSHOT</version>
+			</dependency>
+
+			<!-- Gradle requires the bom to be self-contained -->
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-web-reactive</artifactId>
+				<version>${spring.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-all</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-buffer</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-common</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler-proxy</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport-udt</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport-sctp</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport-rxtx</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-resolver-dns</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-stomp</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-socks</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.projectreactor.ipc</groupId>
+				<artifactId>reactor-netty</artifactId>
+				<version>${reactor-ipc.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.reactivex</groupId>
+				<artifactId>rxnetty-common</artifactId>
+				<version>${rx-netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.reactivex</groupId>
+				<artifactId>rxnetty-http</artifactId>
+				<version>${rx-netty.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+</project>

--- a/spring-boot-sample-web-reactive/pom.xml
+++ b/spring-boot-sample-web-reactive/pom.xml
@@ -2,23 +2,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
 	<parent>
 		<groupId>org.springframework.boot.experimental</groupId>
-		<artifactId>spring-boot-web-reactive</artifactId>
-		<relativePath>../</relativePath>
+		<artifactId>spring-boot-web-reactive-parent</artifactId>
 		<version>0.1.0.BUILD-SNAPSHOT</version>
+		<relativePath>../spring-boot-web-reactive-parent</relativePath>
 	</parent>
-
 	<artifactId>spring-boot-sample-web-reactive</artifactId>
 	<name>Sample project for Spring Boot Web Reactive</name>
-	<description>Sample project for Spring Boot Web Reactive</description>
-
-	<properties>
-		<spring.version>5.0.0.BUILD-SNAPSHOT</spring.version>
-		<reactor.version>3.0.0.BUILD-SNAPSHOT</reactor.version>
-		<reactor-netty.version>0.5.0.BUILD-SNAPSHOT</reactor-netty.version>
-	</properties>
+	<description>Spring Boot Web Reactive Sample</description>
 
 	<dependencies>
 		<dependency>
@@ -41,7 +33,6 @@
 		<dependency>
 			<groupId>io.projectreactor.ipc</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>${reactor-netty.version}</version>
 		</dependency>
 		-->
 
@@ -60,12 +51,10 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlet</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		-->
 
@@ -84,12 +73,10 @@
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxnetty-common</artifactId>
-			<version>0.5.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxnetty-http</artifactId>
-			<version>0.5.2-SNAPSHOT</version>
 		</dependency>
 		-->
 
@@ -108,27 +95,23 @@
 		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-core</artifactId>
-			<version>1.4.0.CR3</version>
 		</dependency>
 		-->
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- Using Reactor Netty HTTP client in tests -->
 		<dependency>
 			<groupId>io.projectreactor.ipc</groupId>
 			<artifactId>reactor-netty</artifactId>
-			<version>${reactor-netty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.0.Final</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-boot-starter-web-reactive/pom.xml
+++ b/spring-boot-starter-web-reactive/pom.xml
@@ -4,11 +4,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.experimental</groupId>
-		<artifactId>spring-boot-web-reactive</artifactId>
+		<artifactId>spring-boot-web-reactive-parent</artifactId>
 		<version>0.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>../</relativePath> <!-- lookup parent from repository -->
+		<relativePath>../spring-boot-web-reactive-parent</relativePath>
 	</parent>
-
 	<artifactId>spring-boot-starter-web-reactive</artifactId>
 	<name>Spring Boot Web Reactive Starter</name>
 	<description>Spring Boot Web Reactive Starter</description>
@@ -34,12 +33,5 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<!-- TODO this shouldn't be there -->
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-buffer</artifactId>
-			<version>4.1.0.Final</version>
-		</dependency>
-
 	</dependencies>
 </project>

--- a/spring-boot-web-reactive-parent/pom.xml
+++ b/spring-boot-web-reactive-parent/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot.experimental</groupId>
+		<artifactId>spring-boot-dependencies-web-reactive</artifactId>
+		<version>0.1.0.BUILD-SNAPSHOT</version>
+		<relativePath>../spring-boot-dependencies-web-reactive</relativePath>
+	</parent>
+	<artifactId>spring-boot-web-reactive-parent</artifactId>
+	<packaging>pom</packaging>
+	<name>Spring Boot Web Reactive Parent</name>
+
+	<properties>
+		<java.version>1.8</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<includes>
+						<include>**/*Tests.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/Abstract*.java</exclude>
+					</excludes>
+					<systemPropertyVariables>
+						<java.security.egd>file:/dev/./urandom</java.security.egd>
+						<java.awt.headless>true</java.awt.headless>
+					</systemPropertyVariables>
+					<argLine>-Xmx1024m</argLine>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>repositories</id>
+			<activation>
+				<property>
+					<name>!skip-repositories</name>
+				</property>
+			</activation>
+			<repositories>
+				<repository>
+					<id>spring-snapshots</id>
+					<url>http://repo.spring.io/snapshot</url>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</repository>
+				<repository>
+					<id>oss-jfrog-snapshots</id>
+					<url>https://oss.jfrog.org/libs-snapshot</url>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</repository>
+				<repository>
+					<id>spring-milestone</id>
+					<url>http://repo.spring.io/milestone</url>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
+
+</project>


### PR DESCRIPTION
This commit adds a bom infrastructure to the experimental reactive
integration in Spring Boot. The purpose of that bom is to mimic what
the regular spring boot bom does with all the necessary overrides and
customizations that the reactive support requires.
