### PR TITLE
Upgrade to reactor-netty 0.6 snapshots

### DIFF
--- a/spring-boot-autoconfigure-web-reactive/src/main/java/org/springframework/boot/autoconfigure/reactiveweb/ReactiveHttpServerConfiguration.java
+++ b/spring-boot-autoconfigure-web-reactive/src/main/java/org/springframework/boot/autoconfigure/reactiveweb/ReactiveHttpServerConfiguration.java
@@ -17,7 +17,7 @@ package org.springframework.boot.autoconfigure.reactiveweb;
 
 import io.reactivex.netty.protocol.http.server.HttpServerImpl;
 import io.undertow.Undertow;
-import reactor.ipc.netty.http.HttpServer;
+import reactor.ipc.netty.http.server.HttpServer;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/spring-boot-dependencies-web-reactive/pom.xml
+++ b/spring-boot-dependencies-web-reactive/pom.xml
@@ -22,7 +22,7 @@
 
 	<properties>
 		<netty.version>4.1.6.Final</netty.version>
-		<reactor-netty.version>0.5.2.RELEASE</reactor-netty.version>
+		<reactor-netty.version>0.6.0.BUILD-SNAPSHOT</reactor-netty.version>
 		<rxjava.version>1.2.2</rxjava.version>
 		<rxjava2.version>2.0.0</rxjava2.version>
 		<rxjava-adapter.version>1.2.0</rxjava-adapter.version>


### PR DESCRIPTION
I've upgraded to reactor-netty 0.6 replicating what was already done in spring-framework master. The tests pass (and so they do in the spring-framework). However when running a sample, the server starts and then exits immediately.
````
2016-11-23 15:45:16.245  INFO 28679 --- [           main] s.w.reactive.ReactiveSampleApplication   : Started ReactiveSampleApplication in 2.116 seconds 
2016-11-23 15:45:16.441  INFO 28679 --- [       Thread-6] o.s.b.c.e.ReactiveWebApplicationContext  : Closing org.springframework.boot.context.embedded.ReactiveWebApplicationContext@3786ea86: startup date [Wed Nov 23 15:45:14 EST 2016]; root of context hierarchy
````

@bclozel any idea what could lead to this? 
@smaldini perhaps some daemon related settings changed in 0.6? 
